### PR TITLE
fix `input.js` file entries in source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,8 @@ function createStream (opts) {
     let ast
     const string = transformAst(source, {
       locations: true,
-      ecmaVersion: 9
+      ecmaVersion: 9,
+      inputFilename: file
     }, (node) => {
       if (node.type === 'Program') ast = node
     })


### PR DESCRIPTION
In some cases when common-shakekify is used browserify generates source maps in which some of the file base names are replaced with `input.js`

`transform-ast` default file name for source maps is `input.js` and before this change we didn't pass `inputFilename` option to `transformAst` function.

This change seems to help (source maps have real names of the files) although I am not sure exactly why this error does not show up in the tests or example.