### PR TITLE
Fix code gen when removed expression is wrapped in parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,15 @@ function createStream (opts) {
       else if (node.parent.type === 'ExpressionStatement') {
         prefix += 'void '
       }
-      string.overwrite(node.start, node.right.start, prefix)
+
+      // Acorn silently strips parens, and node.right.start might be after one
+      // or more parenthesis that we need to keep. Eg, exports.a = (1+1)
+      if (node.right.end !== node.end) {
+        // Replace entire expression. node.start - node.end will wrap the entire expression.
+        string.overwrite(node.start, node.end, prefix + '(' + node.right.getSource() + ')')
+      } else {
+        string.overwrite(node.start, node.right.start, prefix)
+      }
       return
     } else if (node.type === 'Property') {
       // We may have to also overwrite a comma here, eg in `module.exports = {a, b, c}`

--- a/test/paren-exports/a.js
+++ b/test/paren-exports/a.js
@@ -1,0 +1,6 @@
+exports.a = a => a
+
+exports.z = (1+1)
+exports.b = ((a, b) => a ? b : !b)
+exports.c = (function (a, b) {})
+exports.d = (async function (a, b) {})

--- a/test/paren-exports/app.js
+++ b/test/paren-exports/app.js
@@ -1,0 +1,1 @@
+console.log(require('./a').a)

--- a/test/paren-exports/expected.js
+++ b/test/paren-exports/expected.js
@@ -1,0 +1,12 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+exports.a = a => a
+
+/* common-shake removed: exports.z = */ void (1+1)
+/* common-shake removed: exports.b = */ void 0, ((a, b) => a ? b : !b)
+/* common-shake removed: exports.c = */ void (function (a, b) {})
+/* common-shake removed: exports.d = */ void (async function (a, b) {})
+
+},{}],2:[function(require,module,exports){
+console.log(require('./a').a)
+
+},{"./a":1}]},{},[2]);

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,9 @@ test('semi', function (t) {
 test('simple', function (t) {
   runTest(t, 'simple')
 })
+test('paren-exports', function (t) {
+  runTest(t, 'paren-exports')
+})
 
 test('external', function (t) {
   var b = browserify({


### PR DESCRIPTION
This fixes #18, which you can run into very easily using tinyify because uglify runs before common-shakeify and it loves to wrap expressions in parenthesis.

Note as per the issue, there's a slightly simpler & cleaner solution to this by modifying [common-shake](https://github.com/goto-bus-stop/common-shake) to allow parenthesis support in the walked tree.