### PR TITLE
Don't shake when onExportDelete returns false

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,8 +136,9 @@ function createStream (opts) {
 
       module.getDeclarations().forEach((decl) => {
         if (!isUsed(decl.name)) {
-          opts.onExportDelete(row.sourceFile || row.file, decl.name)
-          remove(string, decl.ast)
+          if (opts.onExportDelete(row.sourceFile || row.file, decl.name) !== false) {
+            remove(string, decl.ast)
+          }
         }
       })
 

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ common-shake: bailed out: `module.exports` assignment in node_modules/process-ne
 ### `onExportDelete(filename, exportName)`
 
 Handler called for every exported identifier that is being removed.
-`filename` is the path to the file that exports the identifier. `exportName` is the name of the identifier.
+`filename` is the path to the file that exports the identifier. `exportName` is the name of the identifier. Return false to bail and keep the identifier.
 
 ### `onModuleBailout(module, reasons)`
 

--- a/test/exclude/a.js
+++ b/test/exclude/a.js
@@ -1,0 +1,8 @@
+exports.a = 1
+exports.b = 2
+exports.c = 3
+exports.d = 4
+exports.e = 5
+exports.f = 6
+exports.g = 7
+exports.h = 8

--- a/test/exclude/app.js
+++ b/test/exclude/app.js
@@ -1,0 +1,1 @@
+console.log(require('./a').a)

--- a/test/exclude/expected.js
+++ b/test/exclude/expected.js
@@ -1,0 +1,14 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+exports.a = 1
+exports.b = 2
+/* common-shake removed: exports.c = */ void 3
+/* common-shake removed: exports.d = */ void 4
+/* common-shake removed: exports.e = */ void 5
+/* common-shake removed: exports.f = */ void 6
+/* common-shake removed: exports.g = */ void 7
+/* common-shake removed: exports.h = */ void 8
+
+},{}],2:[function(require,module,exports){
+console.log(require('./a').a)
+
+},{"./a":1}]},{},[2]);

--- a/test/exclude/options.js
+++ b/test/exclude/options.js
@@ -1,0 +1,7 @@
+module.exports = (t) => {
+  return {
+    onExportDelete (file, name) {
+      if (name === 'b') return false
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,9 @@ test('semi', function (t) {
 test('simple', function (t) {
   runTest(t, 'simple')
 })
+test('exclude', function (t) {
+  runTest(t, 'exclude')
+})
 test('paren-exports', function (t) {
   runTest(t, 'paren-exports')
 })


### PR DESCRIPTION
Don't shake when `onExportDelete` returns `false` allowing users explicitly keep exports.