### PR TITLE
Fix class expression and leaky function expr in alias assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,13 +188,10 @@ function createStream (opts) {
           node.right.type === 'ArrowFunctionExpression') {
         // ignore alias assignment expression `exports.a = exports.b = exports.c`
         // unless the last argument is noname function
-        if (!(
-          node.right.type === 'AssignmentExpression' &&
-          node.right.left.type === 'MemberExpression' &&
-          node.right.left.object.name === 'exports'
-          ) ||
-          (node.right.right.type === 'FunctionExpression' && !node.right.right.id)
-          ) {
+        var isAliasAssignment = node.right.type === 'AssignmentExpression' && node.right.left.type === 'MemberExpression' && node.right.left.object.name === 'exports'
+        var isFunction = isAliasAssignment && node.right.right.type === 'FunctionExpression'
+        var isClass = isAliasAssignment && node.right.right.type === 'ClassExpression'
+        if (!isAliasAssignment || isFunction || isClass) {
           prefix += 'void 0, '
         }
       }

--- a/test/multiple-assign/a.js
+++ b/test/multiple-assign/a.js
@@ -5,3 +5,10 @@ exports.a = 'a'
 exports.b = 'b'
 
 exports.c = exports.d = function () {}
+
+exports.e = exports.f = () => {}
+exports.g = exports.h = class {}
+
+// should not leak
+exports.i = exports.j = class named {}
+exports.k = exports.l = function named3 () {}

--- a/test/multiple-assign/expected.js
+++ b/test/multiple-assign/expected.js
@@ -7,6 +7,13 @@ exports.a = 'a'
 
 /* common-shake removed: exports.c = */ void 0, /* common-shake removed: exports.d = */ function () {}
 
+/* common-shake removed: exports.e = */ /* common-shake removed: exports.f = */ void 0, () => {}
+/* common-shake removed: exports.g = */ void 0, /* common-shake removed: exports.h = */ class {}
+
+// should not leak
+/* common-shake removed: exports.i = */ void 0, /* common-shake removed: exports.j = */ class named {}
+/* common-shake removed: exports.k = */ void 0, /* common-shake removed: exports.l = */ function named3 () {}
+
 },{}],2:[function(require,module,exports){
 console.log(require('./a').a)
 


### PR DESCRIPTION
I think this could actually be simplified again but for now this will do.

This fixes an issue where
```js
exports.a = exports.b = class {}
```
generated invalid code, and an issue where
```js
exports.a = exports.b = class a {}
exports.c = exports.d = function a {}
```
would turn the class/fn expressions into declaration statements, leaking the name to the parent scope.