### PR TITLE
Entirely remove side-effect-free unused modules, closes #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-node_modules/
+/node_modules
+!test/*/node_modules
 actual.js
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/browserify/common-shakeify#readme",
   "dependencies": {
-    "@goto-bus-stop/common-shake": "^2.2.0",
+    "@goto-bus-stop/common-shake": "^2.3.0",
     "convert-source-map": "^1.5.1",
     "through2": "^2.0.3",
     "transform-ast": "^2.4.3",

--- a/test/side-effects/app.js
+++ b/test/side-effects/app.js
@@ -1,0 +1,3 @@
+var dep = require('./dep')
+
+console.log(dep.three())

--- a/test/side-effects/dep.js
+++ b/test/side-effects/dep.js
@@ -1,0 +1,4 @@
+var _ = require('functional')
+
+exports.two = function () { return _.addOne(1) }
+exports.three = function () { return 3 }

--- a/test/side-effects/expected.js
+++ b/test/side-effects/expected.js
@@ -1,0 +1,12 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+var dep = require('./dep')
+
+console.log(dep.three())
+
+},{"./dep":2}],2:[function(require,module,exports){
+var _ = void 0 /* require('functional') */
+
+/* common-shake removed: exports.two = */ void function () { return _.addOne(1) }
+exports.three = function () { return 3 }
+
+},{}]},{},[1]);

--- a/test/side-effects/node_modules/functional/index.js
+++ b/test/side-effects/node_modules/functional/index.js
@@ -1,0 +1,2 @@
+exports.addOne = function (x) { return x + 1 }
+exports.addTwo = function (x) { return x + 2 }

--- a/test/side-effects/node_modules/functional/package.json
+++ b/test/side-effects/node_modules/functional/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,9 @@ test('exclude', function (t) {
 test('paren-exports', function (t) {
   runTest(t, 'paren-exports')
 })
+test('side-effects', function (t) {
+  runTest(t, 'side-effects')
+})
 
 test('external', function (t) {
   var b = browserify({


### PR DESCRIPTION
If a module has `sideEffects: false` in its nearest package.json, and none of its exports are used, it is excluded from the bundle.