### PR TITLE
full paths hotfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = function commonShake (b, opts) {
   }, opts)
 
   opts.sourceMap = !!b._options.debug
+  opts.fullPaths = !!b._options.fullPaths
 
   addHooks()
   b.on('reset', addHooks)
@@ -60,7 +61,7 @@ function createStream (opts) {
   return through.obj(onfile, onend)
 
   function onfile (row, enc, next) {
-    const index = row.index
+    const index = opts.fullPaths ? row.file : row.index
     let source = row.source
 
     if (row.dedupe) {
@@ -88,9 +89,10 @@ function createStream (opts) {
     })
     analyzer.run(ast, index)
 
-    Object.keys(row.indexDeps).forEach((name) => {
-      if (row.indexDeps[name]) {
-        analyzer.resolve(index, name, row.indexDeps[name])
+    const deps = opts.fullPaths ? row.deps : row.indexDeps
+    Object.keys(deps).forEach((name) => {
+      if (deps[name]) {
+        analyzer.resolve(index, name, deps[name])
       }
     })
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ const wrapComment = require('wrap-comment')
 const through = require('through2')
 const convertSourceMap = require('convert-source-map')
 
-const kDuplicates = Symbol('duplicates')
-
 module.exports = function commonShake (b, opts) {
   if (typeof b !== 'object') {
     throw new Error('common-shakeify: must be used as a plugin, not a transform')
@@ -57,6 +55,7 @@ function createStream (opts) {
 
   const rows = new Map()
   const strings = new Map()
+  const duplicates = new Map()
 
   return through.obj(onfile, onend)
 
@@ -227,14 +226,15 @@ function createStream (opts) {
   function commentify (str) {
     return wrapComment(`common-shake removed: ${str}`)
   }
-}
 
-function addDuplicate (row, dupe) {
-  if (!row[kDuplicates]) {
-    row[kDuplicates] = []
+  function addDuplicate (row, dupe) {
+    if (!duplicates.has(row)) {
+      duplicates.set(row, [dupe])
+    } else {
+      duplicates.get(row).push(dupe)
+    }
   }
-  row[kDuplicates].push(dupe)
-}
-function getDuplicates (row) {
-  return row[kDuplicates] || []
+  function getDuplicates (row) {
+    return duplicates.get(row) || []
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -175,13 +175,13 @@ test('dash-r node_modules with full paths', { skip: true }, function (t) {
   bundle.on('error', t.fail)
 
   bundle.pipe(fs.createWriteStream(
-    path.join(__dirname, 'dash-r-node-modules/actual.js')
+    path.join(__dirname, 'dash-r-node-modules/actual-fullpaths.js')
   ))
 
   bundle.pipe(concat(function (result) {
     t.is(
       result.toString('utf8'),
-      fs.readFileSync(path.join(__dirname, 'dash-r-node-modules/expected.js'), 'utf8'),
+      fs.readFileSync(path.join(__dirname, 'dash-r-node-modules/expected-fullpaths.js'), 'utf8'),
       'dash-r'
     )
     t.end()

--- a/test/test.js
+++ b/test/test.js
@@ -161,3 +161,29 @@ test('dash-r node_modules', function (t) {
     t.end()
   }))
 })
+
+// TODO fix this one
+test('dash-r node_modules with full paths', { skip: true }, function (t) {
+  var b = browserify({
+    fullPaths: true,
+    entries: path.join(__dirname, 'dash-r-node-modules/app.js')
+  })
+  b.require('net-browserify-stub', { expose: 'net' })
+  b.plugin(commonShake)
+
+  var bundle = b.bundle()
+  bundle.on('error', t.fail)
+
+  bundle.pipe(fs.createWriteStream(
+    path.join(__dirname, 'dash-r-node-modules/actual.js')
+  ))
+
+  bundle.pipe(concat(function (result) {
+    t.is(
+      result.toString('utf8'),
+      fs.readFileSync(path.join(__dirname, 'dash-r-node-modules/expected.js'), 'utf8'),
+      'dash-r'
+    )
+    t.end()
+  }))
+})


### PR DESCRIPTION
This reverts to the 0.6.0 behaviour if the browserify `fullPaths: true` option is set. That means that `-r` will be buggy if you use `fullPaths: true`, but will keep working correctly without it.

Fixes #32 