### PR TITLE
Bump ecmaVersion for issues with try {} catch {}

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function createStream (opts) {
     let ast
     const string = transformAst(source, {
       locations: true,
-      ecmaVersion: 9,
+      ecmaVersion: 10,
       inputFilename: row.file
     }, (node) => {
       if (node.type === 'Program') ast = node


### PR DESCRIPTION
When using `common-shakeify` together with `browserify`, you run into issues inside `acorn` since it finds try/catch blocks without the `(err)` for the exception and the `ecmaVersion` is too low.

Basically, `acorn` throws an error if `ecmaVersion` is lower than 10 https://github.com/acornjs/acorn/blob/9c2cad5c9b51235a1933d45d7b5998849e6f8a7d/acorn/src/statement.js#L352