### PR TITLE
fix for when getSideEffects loop gets stuck

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,8 +61,10 @@ module.exports = function commonShake (b, opts) {
         const file = aliases.get(name) || name
         let pkg
         let dir = file
-        while (!pkg && (dir = path.dirname(dir))) {
+        let prevDir = null
+        while (!pkg && (dir = path.dirname(dir)) && prevDir !== dir) {
           pkg = packages.get(dir)
+          prevDir = dir
         }
         return pkg && pkg.sideEffects === false ? false : true
       }


### PR DESCRIPTION
When I tried updating tinyify to use this module, it got stuck in a loop for `getSideEffects()` with `dir==='/'`. This patch checks that the previous path isn't the same as the current path for an additional check so it doesn't get stuck in a loop.