### PR TITLE
Fix sequential expressions

### DIFF
--- a/test/funny-exports/expected.js
+++ b/test/funny-exports/expected.js
@@ -13,6 +13,6 @@ var c = (0, /* common-shake removed: exports.c = */ 'beep boop')
 
 /* common-shake removed: exports.d = */ exports.e = null
 
-/* common-shake removed: exports.f = */ void {},/* common-shake removed: exports.g = */ void 'g'
+/* common-shake removed: exports.f = */ void {},/* common-shake removed: exports.g = */ void 'g',/* common-shake removed: exports.h = */ void 0, () => {},/* common-shake removed: exports.i = */ void 0, function () {}
 
 },{}]},{},[1]);

--- a/test/funny-exports/expected.js
+++ b/test/funny-exports/expected.js
@@ -13,4 +13,6 @@ var c = (0, /* common-shake removed: exports.c = */ 'beep boop')
 
 /* common-shake removed: exports.d = */ exports.e = null
 
+/* common-shake removed: exports.f = */ void {},/* common-shake removed: exports.g = */ void 'g'
+
 },{}]},{},[1]);

--- a/test/funny-exports/funny.js
+++ b/test/funny-exports/funny.js
@@ -6,3 +6,5 @@ function a() {} exports.b = function () { return a }, console.log(a)
 var c = (0, exports.c = 'beep boop')
 
 exports.d = exports.e = null
+
+exports.f = {},exports.g = 'g'

--- a/test/funny-exports/funny.js
+++ b/test/funny-exports/funny.js
@@ -7,4 +7,4 @@ var c = (0, exports.c = 'beep boop')
 
 exports.d = exports.e = null
 
-exports.f = {},exports.g = 'g'
+exports.f = {},exports.g = 'g',exports.h = () => {},exports.i = function () {}


### PR DESCRIPTION
Handle sequential expressions with values other than functions and class expressions.

## Input
```js
exports.a={},exports.b='hello'
```

## Output
```js
// Before
/* common-shake removed: exports.a = */ {},/* common-shake removed: exports.b = */ 'hello'

// After
/* common-shake removed: exports.a = */ void {},/* common-shake removed: exports.b = */ void 'hello'
```